### PR TITLE
getItem returns null for unknown key

### DIFF
--- a/src/angular-localForage.js
+++ b/src/angular-localForage.js
@@ -161,14 +161,16 @@
             if(found === key.length) {
               return res;
             }
+          }).then(function() {
+            deferred.resolve(res);
           });
         } else {
-          promise = self._localforage.getItem(self.prefix() + key);
+          promise = self._localforage.getItem(self.prefix() + key).then(function(item) {
+            deferred.resolve(item);
+          });
         }
 
-        promise.then(function success(item) {
-          deferred.resolve(item || res);
-        }, function error(data) {
+        promise.then(null, function error(data) {
           self.onError(data, args, self.getItem, deferred);
         });
 

--- a/tests/angular-localForage.js
+++ b/tests/angular-localForage.js
@@ -61,6 +61,16 @@ describe('Module: LocalForageModule', function() {
     expect(typeof $localForage.getItem).toBe('function');
   });
 
+  it('getItem produces null value for unknown key', function(done) {
+    var interval = triggerDigests();
+
+    $localForage.getItem('this key is unknown').then(function(value) {
+      stopDigests(interval);
+      expect(value).toBeNull()
+      done();
+    }, done);
+  });
+
   it('setItem and getItem should work', function(done) {
     var interval = triggerDigests();
 
@@ -117,7 +127,7 @@ describe('Module: LocalForageModule', function() {
 
         $localForage.getItem('myName').then(function(data) {
           stopDigests(interval);
-          expect(data).toBeUndefined();
+          expect(data).toBeNull();
           done();
         }, done);
 
@@ -159,7 +169,7 @@ describe('Module: LocalForageModule', function() {
 
         $localForage.getItem('myName').then(function(data) {
           stopDigests(interval);
-          expect(data).toBeUndefined();
+          expect(data).toBeNull();
           done();
         }, done);
 


### PR DESCRIPTION
This fixes #55 

# Changes

- `getItem` now returns null for unknown key
- Changed tests for `removeItem` and `pull` that were doing `expect(...).toBeUndefined()`

# Note

When given an array of keys like `['known1', 'unknown', 'known2']`, getItem returns `[value1, undefined, value2]`. Maybe that 2nd value should be null for consistency?

I left it as is since `getItem(array)` doesn't have an analog in localforage. Being different from localforage was the source of confusion in #55.