### PR TITLE
Fix binding with falsey default values.

### DIFF
--- a/src/angular-localForage.js
+++ b/src/angular-localForage.js
@@ -365,9 +365,9 @@
           model = $parse(scopeKey);
 
         return self.getItem(opts.key).then(function(item) {
-          if(item) { // If it does exist assign it to the $scope value
+          if (item !== null) { // If it does exist assign it to the $scope value
             model.assign($scope, item);
-          } else if(opts.defaultValue) { // If a value doesn't already exist store it as is
+          } else if(!angular.isUndefined(opts.defaultValue)) { // If a value doesn't already exist store it as is
             model.assign($scope, opts.defaultValue);
             self.setItem(opts.key, opts.defaultValue);
           }

--- a/tests/angular-localForage.js
+++ b/tests/angular-localForage.js
@@ -66,11 +66,11 @@ describe('Module: LocalForageModule', function() {
 
     $localForage.getItem('this key is unknown').then(function(value) {
       stopDigests(interval);
-      expect(value).toBeNull()
+      expect(value).toBeNull();
       done();
     }, done);
   });
-
+  
   it('setItem and getItem should work', function(done) {
     var interval = triggerDigests();
 
@@ -85,7 +85,7 @@ describe('Module: LocalForageModule', function() {
 
     }, done);
   });
-
+  
   it('setItem and getItem should work with an array of keys', function(done) {
     var interval = triggerDigests(),
       values = ['Olivier Combe', 'AngularJs', 'Open Source'];
@@ -325,6 +325,40 @@ describe('Module: LocalForageModule', function() {
     expect(function() {
       $localForage.setItem();
     }).toThrowError('You must define a key to set');
+  });
+  
+  describe("bind", function() {
+    var $scope, $q;
+    
+    beforeEach(inject(function($rootScope, _$q_){
+      $scope = $rootScope;
+      $q = _$q_;
+    }));
+    
+    it(' should use the default stored value if nothing has been previously stored', function(done){
+      // Check different types of items.
+      var testItems = [ { foo: 'bar' }, ["cat", "dog", "pidgeon"], 123, 0, true, false ]
+      var promises = [];
+      // Store all the items, deleting old values
+      for(var i = 0; i < testItems.length; i++){
+        $localForage.removeItem('item' + i);
+        var item = testItems[i];
+        promises.push(
+          $localForage.bind($scope, {
+            key: 'item' + i,
+            defaultValue: item,
+          })
+        );
+      }
+      // After all promises have been resolved, check the items are what we expect them to be.
+      $q.all(promises).then(function(){      
+        for(var i = 0; i < testItems.length; i++){
+          expect($scope['item' + i]).toBe(testItems[i]);
+        }
+      });
+      done();
+    });
+    
   });
 
   describe("iterate", function() {


### PR DESCRIPTION
Currently, when using bind, if a default is provided but is falsey localForage ignores it.

i.e.

```javascript
$localForage.bind($scope, {
  key: 'someKey',
  defaultValue: false
})
```
Would leave `$scope.someKey` as `undefined`.

Similarly, if a falsey value is already stored, when it is recovered by `bind`, it's disregarded. This is particularly noticable when binding to a boolean with a default value of true - `bind` will *always* set the scope variable to `true`.

I believe this is down to checking for truthiness rather than checking that an item is defined (default value) or not null (recovering a saved value).

I've created a test that checks the behaviour of default bindings which fails without the minor changes I made. I haven't yet made a test to check the case where a falsey value has been stored and recovered by bind.

