### PR TITLE
Adds note that localforage.js must be loaded first

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This angularJS module is a rewrite of [angular-local-storage by grevory](https:/
 ## Usage :
 - Download the project or install via bower `bower install angular-localforage` or npm `npm install angular-localforage`
 - Download localForage https://github.com/mozilla/localForage
-- Put localforage.js and angular-localForage.js into you project
+- Put localforage.js and angular-localForage.js into your project (with localforage.js before angular-localForage.js).
 ```html
 <script src="path/to/localforage.js"></script>
 <script src="path/to/angular-localForage.js"></script>


### PR DESCRIPTION
Since many users will be managing dependencies without copying the example's `<script>` tags, or otherwise re-grouping them in crazy ways, it's helpful to explicitly note that localforage.js must precede angular-localForage.js.

I realized this reading posts in this issue thread: https://github.com/ocombe/angular-localForage/issues/49