### PR TITLE
Change getItem(string[]) to return null for unknown keys instead of undefined

### DIFF
--- a/src/angular-localForage.js
+++ b/src/angular-localForage.js
@@ -162,6 +162,11 @@
               return res;
             }
           }).then(function() {
+            for (var i = 0; i < key.length; i++) {
+              if (angular.isUndefined(res[i])) {
+                res[i] = null;
+              }
+            }
             deferred.resolve(res);
           });
         } else {

--- a/tests/angular-localForage.js
+++ b/tests/angular-localForage.js
@@ -71,6 +71,54 @@ describe('Module: LocalForageModule', function() {
     }, done);
   });
 
+  describe('getItem for an array with unknown keys', function() {
+    it('should produce null values with all unknown keys', function(done) {
+      var interval = triggerDigests();
+
+      $localForage.getItem(['unknown key 1', 'unknown key 2']).then(function(values) {
+        stopDigests(interval);
+        expect(values).toEqual([null, null]);
+        done()
+      }, done)
+    });
+
+    it('should produce null value for an unknown trailing key', function(done) {
+      var interval = triggerDigests();
+
+      $localForage.setItem('known key', 'known value').then(function() {
+        $localForage.getItem(['known key', 'unknown key']).then(function(values) {
+          stopDigests(interval);
+          expect(values).toEqual(['known value', null]);
+          done()
+        }, done)
+      });
+    });
+
+    it('should produce null value for an unknown initial key', function(done) {
+      var interval = triggerDigests();
+
+      $localForage.setItem('known key', 'known value').then(function() {
+        $localForage.getItem(['unknown key', 'known key']).then(function(values) {
+          stopDigests(interval);
+          expect(values).toEqual([null, 'known value']);
+          done()
+        }, done)
+      });
+    });
+
+    it('should produce null value for a unknown middle key', function(done) {
+      var interval = triggerDigests();
+
+      $localForage.setItem(['known key', 'known key 2'], ['known value', 'known value 2']).then(function() {
+        $localForage.getItem(['known key', 'unknown key', 'known key 2']).then(function(values) {
+          stopDigests(interval);
+          expect(values).toEqual(['known value', null, 'known value 2']);
+          done()
+        }, done)
+      });
+    });
+  });
+
   describe("iterate", function() {
     var interval;
 
@@ -173,8 +221,8 @@ describe('Module: LocalForageModule', function() {
 
         $localForage.getItem(['myName', 'myPassion', 'myHobbie']).then(function(data) {
           stopDigests(interval);
-          expect(data[0]).toBeUndefined();
-          expect(data[1]).toBeUndefined();
+          expect(data[0]).toBeNull();
+          expect(data[1]).toBeNull();
           expect(data[2]).toEqual('Open Source');
           done();
         }, done);
@@ -216,8 +264,8 @@ describe('Module: LocalForageModule', function() {
 
         $localForage.getItem(['myName', 'myPassion', 'myHobbie']).then(function(data) {
           stopDigests(interval);
-          expect(data[0]).toBeUndefined();
-          expect(data[1]).toBeUndefined();
+          expect(data[0]).toBeNull();
+          expect(data[1]).toBeNull();
           expect(data[2]).toEqual('Open Source');
           done();
         }, done);


### PR DESCRIPTION
Using regular `#getItem(String)` and `#pull(String)` returns `null` on not-found keys, the array versions return `undefined` which wasn't expected. It also changes the length of the returned array from the initial array:

```
['unknown', 'unknown'] => []
['known', 'unknown'] => ['known']
['unknown', 'known'] => [undefined, 'known']
['known', 'unknown', 'known 2'] => ['known', undefined, 'known 2']
```

I have modified the `#getItem(String[])` to return `null` in place of unknown keys and added test cases + modified the test cases in `#pull(String[])` and `#removeItem(String[])` to use `#toBeNull()` instead of `#toBeUndefined()`
