### PR TITLE
Update localforage dep to 1.4 to get fix for Chrome/Firefox on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/ocombe/angular-localForage/issues"
   },
   "dependencies": {
-    "localforage": "~1.3"
+    "localforage": "~1.4"
   },
   "devDependencies": {
     "gulp": "~3.9.0",


### PR DESCRIPTION
https://github.com/mozilla/localForage/issues/511

The result of it was that neither Chrome or Firefox worked on iOS with versions below 1.4