### PR TITLE
fix: storeName can be used in createInstance and instance functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Iterate supports early exit by returning non `undefined` value inside `iteratorC
 Resulting value will be passed to the promise as the result of iteration.
 You can use this to make a search in your data:
 ```js
-$localForage.iterate(function(value, key) {
+$localForage.iterate(function(value, key, iterationNumber) {
     if(angular.isInt(value) && value > 10) {
         return key;
     }

--- a/src/angular-localForage.js
+++ b/src/angular-localForage.js
@@ -18,7 +18,8 @@
   angularLocalForage.provider('$localForage', function() {
     var lfInstances = {},
       defaultConfig = {
-        name: 'lf'
+        name: 'lf',
+        storeName: 'keyvaluepairs',
       },
     // Send signals for each of the following actions ?
       notify = {
@@ -55,28 +56,51 @@
       LocalForageInstance.prototype.createInstance = function createInstance(config) {
         if(angular.isObject(config)) { // create new instance
           config = angular.extend({}, defaultConfig, config);
-          if(angular.isDefined(lfInstances[config.name])) {
-            throw new Error('A localForage instance with the name ' + config.name + ' is already defined.');
+          var lfInstanceName = config.name + '#' + config.storeName;
+          if(angular.isDefined(lfInstances[lfInstanceName])) {
+              throw new Error('A localForage instance with the name ' +
+                              config.name + ' and storeName ' +
+                              config.storeName + ' is already defined.');
           }
 
-          lfInstances[config.name] = new LocalForageInstance(config);
-          return lfInstances[config.name];
+          lfInstances[lfInstanceName] = new LocalForageInstance(config);
+          return lfInstances[lfInstanceName];
         } else {
-          throw new Error('The parameter should be a config object.')
+          throw new Error('The parameter should be a config object.');
         }
       };
 
       LocalForageInstance.prototype.instance = function instance(name) {
         if(angular.isUndefined(name)) {
-          return lfInstances[defaultConfig.name];
+          return lfInstances[defaultConfig.name + '#' + defaultConfig.storeName];
         } else if(angular.isString(name)) {
-          if(angular.isDefined(lfInstances[name])) {
-            return lfInstances[name];
+          var lfInstanceName = name + '#' + defaultConfig.storeName;
+          if(angular.isDefined(lfInstances[lfInstanceName])) {
+            return lfInstances[lfInstanceName];
           } else {
-            throw new Error('No localForage instance of that name exists.')
+            throw new Error('No localForage instance of that name exists.');
+          }
+        } else if(angular.isObject(name)) {
+          // if it is an object with {name, storeName} properties,
+          // return corresponding instance 
+          var instanceObj = name;
+          if(!angular.isDefined(instanceObj.name) &&
+             !angular.isDefined(instanceObj.storeName)) {
+            throw new Error('instance parameter object needs to contain name or storeName');
+          }
+          var n = (angular.isDefined(instanceObj.name)
+                      ? instanceObj.name
+                      : defaultConfig.name),
+              sn = (angular.isDefined(instanceObj.storeName)
+                      ? instanceObj.storeName
+                      : defaultConfig.storeName);
+          if(angular.isDefined(lfInstances[n + '#' + sn])) {
+            return lfInstances[n + '#' + sn];
+          } else {
+            throw new Error('No localForage instance of that name exists.');
           }
         } else {
-          throw new Error('The parameter should be a string.')
+          throw new Error('The parameter should be a string or object.');
         }
       };
 

--- a/tests/angular-localForage.js
+++ b/tests/angular-localForage.js
@@ -150,6 +150,18 @@ describe('Module: LocalForageModule', function() {
       }, done);
     });
 
+    it('should have an iterationNumber with a 1-index', function(done) {
+      var count;
+
+      $localForage.iterate(function(value, key, iterationNumber) {
+        count = iterationNumber;
+      }).then(function() {
+        stopDigests(interval);
+        expect(count).toEqual(3);
+        done();
+      }, done);
+    })
+
     it('key/value filter should work', function(done) {
       //test key filter
       $localForage.iterate(function(value, key) {

--- a/tests/angular-localForage.js
+++ b/tests/angular-localForage.js
@@ -477,4 +477,50 @@ describe('Module: LocalForageModule', function() {
       }, done);
     });
   });
+
+  describe("instance", function () {
+      var testInstance_1;
+      var testInstance_2;
+      it('should create new instance for a storeName', function () {
+          testInstance_1 = $localForage.createInstance({
+              storeName: 'TEST_INSTANCE_1'
+          });
+      });
+      it('should create new instance for another storeName in same name', function () {
+          testInstance_2 = $localForage.createInstance({
+              storeName: 'TEST_INSTANCE_2'
+          });
+      });
+      it('should give error if user tries to create new instance with already created storeName', function () {
+          var instance = $localForage.createInstance({
+              storeName: 'TEST_INSTANCE_3'
+          });
+          expect(function () {
+              var duplicateInstance = $localForage.createInstance({
+                  storeName: 'TEST_INSTANCE_3'
+              });
+          }).toThrowError();
+      });
+      it('should get created instance', function () {
+          $localForage.createInstance({
+              name: 'testName',
+              storeName: 'TEST_INSTANCE_4'
+          });
+          var instance = $localForage.instance({
+              name: 'testName',
+              storeName: 'TEST_INSTANCE_4'
+          });
+      });
+      it('should not get non-created instance', function () {
+          expect(function () {
+              $localForage.instance({storeName: 'TEST_INSTANCE_4'});
+          }).toThrowError('No localForage instance of that name exists.');
+          expect(function () {
+              $localForage.instance({
+                  name: 'wrongTestName',
+                  storeName: 'TEST_INSTANCE_4'
+              });
+          }).toThrowError('No localForage instance of that name exists.');
+      });
+  });
 });


### PR DESCRIPTION
createInstance({name: 'foo', storeName: 'bar'});
createInstance({name: 'foo', storeName: 'differentName'})

are now allowed.

instance('name') is deprecated but can still be used,
instance({name: 'foo', storeName: 'bar'}) is preferred now.