### PR TITLE
Fix SystemJS loading

### DIFF
--- a/src/angular-localForage.js
+++ b/src/angular-localForage.js
@@ -1,7 +1,7 @@
 (function(root, factory) {
   'use strict';
 
-  var angular = root ? root.angular : window.angular;
+  var angular = (root && root.angular) || (window && window.angular);
   if(typeof define === 'function' && define.amd) {                    // AMD
     define(['localforage'], function(localforage) {
       factory(angular, localforage);


### PR DESCRIPTION
Fix SystemJS (and JSPM) loading by checking whether the empty `root` object (which is not falsy) contains `angular` before using that key.