### PR TITLE
fix: NW.js module is not defined fix.

### DIFF
--- a/dist/angular-localForage.js
+++ b/dist/angular-localForage.js
@@ -14,7 +14,11 @@
       return factory(angular, localforage);
     });
   } else if(typeof exports === 'object' || typeof global === 'object') {
-    module.exports = factory(angular, require('localforage')); // Node/Browserify
+    if(typeof module === 'undefined') {
+      global.module.exports = factory(angular, require('localforage')); // NW.js
+    } else {
+      modules.exports = factory(angular, require('localforage')); // Node/Browserify
+    }
   } else {
     return factory(angular, root.localforage);                        // Browser
   }

--- a/dist/angular-localForage.js
+++ b/dist/angular-localForage.js
@@ -17,7 +17,7 @@
     if(typeof module === 'undefined') {
       global.module.exports = factory(angular, require('localforage')); // NW.js
     } else {
-      modules.exports = factory(angular, require('localforage')); // Node/Browserify
+      module.exports = factory(angular, require('localforage')); // Node/Browserify
     }
   } else {
     return factory(angular, root.localforage);                        // Browser


### PR DESCRIPTION
Now the factory assignment for localforage is applied to
`global.modules.exports` instead of `modules.exports` if `module` is
undefined.
`module` is undefined in an NW.js environment (for whatever
reason). So now we check for module and we uses global if `module`
is undefined. Otherwise we proceed as before.

Thank @ashleyhindle for fix.

Fixes #77 